### PR TITLE
backup rules

### DIFF
--- a/dp3t-sdk/sdk/src/calibration/java/org/dpppt/android/sdk/internal/logger/LogDatabase.java
+++ b/dp3t-sdk/sdk/src/calibration/java/org/dpppt/android/sdk/internal/logger/LogDatabase.java
@@ -127,7 +127,7 @@ class LogDatabase {
 	private static class LogDatabaseHelper extends SQLiteOpenHelper {
 
 		private static final int DATABASE_VERSION = 1;
-		private static final String DATABASE_NAME = "log.db";
+		private static final String DATABASE_NAME = "dp3t_sdk_log.db";
 
 		private static final String SQL_CREATE_ENTRIES =
 				"CREATE TABLE " + LogSpec.TABLE_NAME + " (" +

--- a/dp3t-sdk/sdk/src/main/AndroidManifest.xml
+++ b/dp3t-sdk/sdk/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
-	<application>
+	<application
+		android:fullBackupContent="@xml/dp3t_sdk_backup_rules">
 
 		<service
 			android:name="org.dpppt.android.sdk.internal.TracingService"

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/AppConfigManager.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/AppConfigManager.java
@@ -54,6 +54,7 @@ public class AppConfigManager {
 	private boolean isDevDiscoveryMode;
 	private SharedPreferences sharedPrefs;
 	private DiscoveryRepository discoveryRepository;
+	private final Gson gson = new Gson();
 
 	private AppConfigManager(Context context) {
 		discoveryRepository = new DiscoveryRepository(context);
@@ -69,7 +70,7 @@ public class AppConfigManager {
 		discoveryRepository.getDiscovery(new CallbackListener<ApplicationsList>() {
 			@Override
 			public void onSuccess(ApplicationsList response) {
-				sharedPrefs.edit().putString(PREF_APPLICATION_LIST, new Gson().toJson(response)).commit();
+				sharedPrefs.edit().putString(PREF_APPLICATION_LIST, gson.toJson(response)).apply();
 			}
 
 			@Override
@@ -84,18 +85,18 @@ public class AppConfigManager {
 		setAppId(applicationInfo.getAppId());
 		ApplicationsList applicationsList = new ApplicationsList();
 		applicationsList.getApplications().add(applicationInfo);
-		sharedPrefs.edit().putString(PREF_APPLICATION_LIST, new Gson().toJson(applicationsList)).commit();
+		sharedPrefs.edit().putString(PREF_APPLICATION_LIST, gson.toJson(applicationsList)).apply();
 	}
 
 	public void updateFromDiscoverySynchronous() throws IOException {
 		if (useDiscovery) {
 			ApplicationsList response = discoveryRepository.getDiscoverySync(isDevDiscoveryMode);
-			sharedPrefs.edit().putString(PREF_APPLICATION_LIST, new Gson().toJson(response)).commit();
+			sharedPrefs.edit().putString(PREF_APPLICATION_LIST, gson.toJson(response)).apply();
 		}
 	}
 
 	public ApplicationsList getLoadedApplicationsList() {
-		return new Gson().fromJson(sharedPrefs.getString(PREF_APPLICATION_LIST, "{}"), ApplicationsList.class);
+		return gson.fromJson(sharedPrefs.getString(PREF_APPLICATION_LIST, "{}"), ApplicationsList.class);
 	}
 
 	public ApplicationInfo getAppConfig() {
@@ -108,7 +109,7 @@ public class AppConfigManager {
 	}
 
 	public void setAdvertisingEnabled(boolean enabled) {
-		sharedPrefs.edit().putBoolean(PREF_ADVERTISING_ENABLED, enabled).commit();
+		sharedPrefs.edit().putBoolean(PREF_ADVERTISING_ENABLED, enabled).apply();
 	}
 
 	public boolean isAdvertisingEnabled() {
@@ -116,7 +117,7 @@ public class AppConfigManager {
 	}
 
 	public void setReceivingEnabled(boolean enabled) {
-		sharedPrefs.edit().putBoolean(PREF_RECEIVING_ENABLED, enabled).commit();
+		sharedPrefs.edit().putBoolean(PREF_RECEIVING_ENABLED, enabled).apply();
 	}
 
 	public boolean isReceivingEnabled() {
@@ -124,7 +125,7 @@ public class AppConfigManager {
 	}
 
 	public void setLastSyncDate(long lastSyncDate) {
-		sharedPrefs.edit().putLong(PREF_LAST_SYNC_DATE, lastSyncDate).commit();
+		sharedPrefs.edit().putLong(PREF_LAST_SYNC_DATE, lastSyncDate).apply();
 	}
 
 	public long getLastSyncDate() {
@@ -132,7 +133,7 @@ public class AppConfigManager {
 	}
 
 	public void setLastSyncNetworkSuccess(boolean success) {
-		sharedPrefs.edit().putBoolean(PREF_LAST_SYNC_NET_SUCCESS, success).commit();
+		sharedPrefs.edit().putBoolean(PREF_LAST_SYNC_NET_SUCCESS, success).apply();
 	}
 
 	public boolean getLastSyncNetworkSuccess() {
@@ -144,7 +145,7 @@ public class AppConfigManager {
 	}
 
 	public void setAmIExposed(boolean exposed) {
-		sharedPrefs.edit().putBoolean(PREF_AM_I_EXPOSED, exposed).commit();
+		sharedPrefs.edit().putBoolean(PREF_AM_I_EXPOSED, exposed).apply();
 	}
 
 	public BackendRepository getBackendRepository(Context context) {
@@ -163,7 +164,7 @@ public class AppConfigManager {
 					"CalibrationTestDevice Name must have length " + CALIBRATION_TEST_DEVICE_NAME_LENGTH + ", provided string '" +
 							name + "' with length " + name.length());
 		}
-		sharedPrefs.edit().putString(PREF_CALIBRATION_TEST_DEVICE_NAME, name).commit();
+		sharedPrefs.edit().putString(PREF_CALIBRATION_TEST_DEVICE_NAME, name).apply();
 	}
 
 	public String getCalibrationTestDeviceName() {
@@ -171,7 +172,7 @@ public class AppConfigManager {
 	}
 
 	public void setScanDuration(long scanDuration) {
-		sharedPrefs.edit().putLong(PREF_SCAN_DURATION, scanDuration).commit();
+		sharedPrefs.edit().putLong(PREF_SCAN_DURATION, scanDuration).apply();
 	}
 
 	public long getScanDuration() {
@@ -179,7 +180,7 @@ public class AppConfigManager {
 	}
 
 	public void setScanInterval(long scanInterval) {
-		sharedPrefs.edit().putLong(PREF_SCAN_INTERVAL, scanInterval).commit();
+		sharedPrefs.edit().putLong(PREF_SCAN_INTERVAL, scanInterval).apply();
 	}
 
 	public long getScanInterval() {
@@ -187,7 +188,7 @@ public class AppConfigManager {
 	}
 
 	public void setBluetoothPowerLevel(BluetoothTxPowerLevel powerLevel) {
-		sharedPrefs.edit().putInt(PREF_ADVERTISEMENT_POWER_LEVEL, powerLevel.ordinal()).commit();
+		sharedPrefs.edit().putInt(PREF_ADVERTISEMENT_POWER_LEVEL, powerLevel.ordinal()).apply();
 	}
 
 	public BluetoothTxPowerLevel getBluetoothTxPowerLevel() {
@@ -195,7 +196,7 @@ public class AppConfigManager {
 	}
 
 	public void setBluetoothAdvertiseMode(BluetoothAdvertiseMode advertiseMode) {
-		sharedPrefs.edit().putInt(PREF_ADVERTISEMENT_MODE, advertiseMode.ordinal()).commit();
+		sharedPrefs.edit().putInt(PREF_ADVERTISEMENT_MODE, advertiseMode.ordinal()).apply();
 	}
 
 	public BluetoothAdvertiseMode getBluetoothAdvertiseMode() {
@@ -203,7 +204,7 @@ public class AppConfigManager {
 	}
 
 	public void clearPreferences() {
-		sharedPrefs.edit().clear().commit();
+		sharedPrefs.edit().clear().apply();
 	}
 
 }

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/AppConfigManager.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/AppConfigManager.java
@@ -36,7 +36,7 @@ public class AppConfigManager {
 	private static final int DEFAULT_BLUETOOTH_POWER_LEVEL = BluetoothTxPowerLevel.ADVERTISE_TX_POWER_LOW.getValue();
 	private static final int DEFAULT_BLUETOOTH_ADVERTISE_MODE = BluetoothAdvertiseMode.ADVERTISE_MODE_LOW_POWER.getValue();
 
-	private static final String PREF_NAME = "appConfigPreferences";
+	private static final String PREFS_NAME = "dp3t_sdk_preferences";
 	private static final String PREF_APPLICATION_LIST = "applicationList";
 	private static final String PREF_ADVERTISING_ENABLED = "advertisingEnabled";
 	private static final String PREF_RECEIVING_ENABLED = "receivingEnabled";
@@ -57,7 +57,7 @@ public class AppConfigManager {
 
 	private AppConfigManager(Context context) {
 		discoveryRepository = new DiscoveryRepository(context);
-		sharedPrefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+		sharedPrefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
 	}
 
 	public void setAppId(String appId) {

--- a/dp3t-sdk/sdk/src/main/res/xml/dp3t_sdk_backup_rules.xml
+++ b/dp3t-sdk/sdk/src/main/res/xml/dp3t_sdk_backup_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+	<exclude
+		domain="sharedpref"
+		path="dp3t_sdk_preferences.xml" />
+	<exclude
+		domain="sharedpref"
+		path="dp3t_store.xml" />
+	<exclude
+		domain="database"
+		path="dp3t_sdk.db" />
+	<exclude
+		domain="database"
+		path="dp3t_sdk_log.db" />
+</full-backup-content>


### PR DESCRIPTION
Added Android backup rules to exclude SDK data.

Breaking changes: 
- Renamed config preference file
- Renamed logs database file