### PR TITLE
stop tracing service on invalid intent

### DIFF
--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/TracingService.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/TracingService.java
@@ -57,7 +57,8 @@ public class TracingService extends Service {
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
 		if (intent == null || intent.getAction() == null) {
-			return START_STICKY;
+			stopSelf();
+			return START_NOT_STICKY;
 		}
 
 		if (wl == null) {
@@ -83,7 +84,7 @@ public class TracingService extends Service {
 			stopForegroundService();
 		}
 
-		return START_STICKY;
+		return START_REDELIVER_INTENT;
 	}
 
 	private Notification createForegroundNotification() {


### PR DESCRIPTION
might crash otherwise, since it gets started as non-foreground