### PR TITLE
make sure we store lastSyncCallTime also if provideDiagnosisKeys call…

### DIFF
--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.java
@@ -243,9 +243,11 @@ public class SyncWorker extends Worker {
 							String token = dateToLoad.formatAsString();
 							Logger.d(TAG,
 									"provideDiagnosisKeys for " + dateToLoad.formatAsString() + " with size " + file.length());
+							lastSyncCallTimes.put(dateToLoad, currentTime);
 							googleExposureClient.provideDiagnosisKeys(fileList, token);
+						}else{
+							lastSyncCallTimes.put(dateToLoad, currentTime);
 						}
-						lastSyncCallTimes.put(dateToLoad, currentTime);
 						lastLoadedTimes.put(dateToLoad, Long.parseLong(result.headers().get("x-published-until")));
 						numSuccesses++;
 					} catch (Exception e) {


### PR DESCRIPTION
… throws an (unexpected) exception, otherwise this could lead to rate limit issues.