### PR TITLE
Add error response body to StatusCodeException

### DIFF
--- a/calibration-app/app/src/main/java/org/dpppt/android/calibration/handshakes/BackendCalibrationReportRepository.java
+++ b/calibration-app/app/src/main/java/org/dpppt/android/calibration/handshakes/BackendCalibrationReportRepository.java
@@ -10,7 +10,6 @@
 package org.dpppt.android.calibration.handshakes;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
 
 import org.dpppt.android.calibration.MainApplication;
 import org.dpppt.android.sdk.backend.ResponseCallback;
@@ -18,6 +17,7 @@ import org.dpppt.android.sdk.internal.backend.Repository;
 import org.dpppt.android.sdk.internal.backend.StatusCodeException;
 import org.dpppt.android.sdk.internal.backend.models.GaenRequest;
 
+import androidx.annotation.NonNull;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -46,7 +46,7 @@ public class BackendCalibrationReportRepository implements Repository {
 				if (response.isSuccessful()) {
 					responseCallback.onSuccess(null);
 				} else {
-					onFailure(call, new StatusCodeException(response.raw()));
+					onFailure(call, new StatusCodeException(response.raw(), response.errorBody()));
 				}
 			}
 

--- a/calibration-app/app/src/main/java/org/dpppt/android/calibration/handshakes/BackendUserBucketRepository.java
+++ b/calibration-app/app/src/main/java/org/dpppt/android/calibration/handshakes/BackendUserBucketRepository.java
@@ -10,9 +10,6 @@
 package org.dpppt.android.calibration.handshakes;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-
-import java.io.IOException;
 
 import org.dpppt.android.calibration.MainApplication;
 import org.dpppt.android.sdk.backend.SignatureException;
@@ -20,6 +17,9 @@ import org.dpppt.android.sdk.internal.backend.Repository;
 import org.dpppt.android.sdk.internal.backend.ServerTimeOffsetException;
 import org.dpppt.android.sdk.internal.backend.StatusCodeException;
 
+import java.io.IOException;
+
+import androidx.annotation.NonNull;
 import okhttp3.ResponseBody;
 import retrofit2.Response;
 import retrofit2.Retrofit;
@@ -47,7 +47,7 @@ public class BackendUserBucketRepository implements Repository {
 		if (response.isSuccessful() && response.body() != null) {
 			return response.body();
 		} else {
-			throw new StatusCodeException(response.raw());
+			throw new StatusCodeException(response.raw(), response.errorBody());
 		}
 	}
 

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/BackendBucketRepository.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/BackendBucketRepository.java
@@ -10,15 +10,15 @@
 package org.dpppt.android.sdk.internal.backend;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-
-import java.io.IOException;
-import java.security.PublicKey;
 
 import org.dpppt.android.sdk.backend.SignatureException;
 import org.dpppt.android.sdk.backend.SignatureVerificationInterceptor;
 import org.dpppt.android.sdk.models.DayDate;
 
+import java.io.IOException;
+import java.security.PublicKey;
+
+import androidx.annotation.NonNull;
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 import retrofit2.Response;
@@ -51,7 +51,7 @@ public class BackendBucketRepository implements Repository {
 		if (response.isSuccessful()) {
 			return response;
 		} else {
-			throw new StatusCodeException(response.raw());
+			throw new StatusCodeException(response.raw(), response.errorBody());
 		}
 	}
 

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/BackendReportRepository.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/BackendReportRepository.java
@@ -52,7 +52,7 @@ public class BackendReportRepository implements Repository {
 				if (response.isSuccessful()) {
 					responseCallback.onSuccess(response.headers().get("Authorization"));
 				} else {
-					onFailure(call, new StatusCodeException(response.raw()));
+					onFailure(call, new StatusCodeException(response.raw(), response.errorBody()));
 				}
 			}
 
@@ -66,7 +66,7 @@ public class BackendReportRepository implements Repository {
 	public void addPendingGaenKey(GaenKey gaenKey, String token) throws IOException, StatusCodeException {
 		Response<Void> response = reportService.addPendingGaenKey(new GaenSecondDay(gaenKey), token).execute();
 		if (!response.isSuccessful()) {
-			throw new StatusCodeException(response.raw());
+			throw new StatusCodeException(response.raw(), response.errorBody());
 		}
 	}
 

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/StatusCodeException.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/StatusCodeException.java
@@ -9,27 +9,52 @@
  */
 package org.dpppt.android.sdk.internal.backend;
 
+import java.io.IOException;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 public class StatusCodeException extends Exception {
 
 	private Response response;
+	private String body;
 
-	public StatusCodeException(@NonNull Response response) {
+	public StatusCodeException(@NonNull Response response, @Nullable ResponseBody errorBody) {
 		this.response = response;
+		this.body = readBody(errorBody);
 	}
 
 	@Nullable
 	@Override
 	public String getMessage() {
-		return "Code: " + response.code() + " Message: " + response.message();
+		StringBuilder sb = new StringBuilder()
+				.append("Code: ")
+				.append(response.code())
+				.append(" Message: ")
+				.append(response.message());
+		if (body != null) {
+			sb.append(" Body: ").append(body);
+		}
+		return sb.toString();
+	}
+
+	@Nullable
+	public String getBody() {
+		return body;
 	}
 
 	public int getCode() {
 		return response.code();
 	}
 
+	private static String readBody(ResponseBody body) {
+		try {
+			return body == null ? null : body.string();
+		} catch (IOException error) {
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
Add the ability to pass error response body to the client application.
It is up to the client application to handle the contents of the error response.
Helps with error handling and debugging as client applications can show more details error messages to users.

Related iOS SDK pull request:
https://github.com/DP-3T/dp3t-sdk-ios/pull/185