### PR TITLE
Feature/increas number of uploaded keys

### DIFF
--- a/dp3t-sdk/sdk/src/androidTest/AndroidManifest.xml
+++ b/dp3t-sdk/sdk/src/androidTest/AndroidManifest.xml
@@ -21,6 +21,13 @@
 		tools:ignore="HardcodedDebugMode"
 		tools:replace="android:debuggable">
 
+		<activity android:name=".TestActivity">
+			<intent-filter>
+				<action android:name="android.intent.action.MAIN" />
+				<category android:name="android.intent.category.LAUNCHER" />
+			</intent-filter>
+		</activity>
+
 	</application>
 
 </manifest>

--- a/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/SyncWorkerTest.java
+++ b/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/SyncWorkerTest.java
@@ -19,6 +19,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.dpppt.android.sdk.BuildConfig;
 import org.dpppt.android.sdk.DP3T;
 import org.dpppt.android.sdk.InfectionStatus;
 import org.dpppt.android.sdk.TracingStatus;
@@ -74,6 +75,9 @@ public class SyncWorkerTest {
 
 	@Test
 	public void testSyncStartAtMorning() {
+		if (!BuildConfig.FLAVOR.equals("production")) {
+			throw new IllegalStateException("Wrong Build Variant. Make sure to run this Test with the production build variant.");
+		}
 		AtomicLong time = new AtomicLong(yesterdayAt3am());
 
 		server.setDispatcher(new Dispatcher() {
@@ -109,6 +113,9 @@ public class SyncWorkerTest {
 
 	@Test
 	public void testSyncStartEvening() throws Exception {
+		if (!BuildConfig.FLAVOR.equals("production")) {
+			throw new IllegalStateException("Wrong Build Variant. Make sure to run this Test with the production build variant.");
+		}
 		AtomicLong time = new AtomicLong(yesterdayAt8pm());
 
 		server.setDispatcher(new Dispatcher() {
@@ -131,6 +138,9 @@ public class SyncWorkerTest {
 
 	@Test
 	public void testSyncDelayedInEvening() throws Exception {
+		if (!BuildConfig.FLAVOR.equals("production")) {
+			throw new IllegalStateException("Wrong Build Variant. Make sure to run this Test with the production build variant.");
+		}
 		AtomicLong time = new AtomicLong(yesterdayAt8am());
 
 		server.setDispatcher(new Dispatcher() {

--- a/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/TEKReleaseTest.java
+++ b/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/TEKReleaseTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package org.dpppt.android.sdk.internal;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Context;
+import android.content.Intent;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import org.dpppt.android.sdk.DP3T;
+import org.dpppt.android.sdk.InfectionStatus;
+import org.dpppt.android.sdk.backend.ResponseCallback;
+import org.dpppt.android.sdk.internal.backend.ProxyConfig;
+import org.dpppt.android.sdk.internal.backend.models.GaenKey;
+import org.dpppt.android.sdk.internal.backend.models.GaenRequest;
+import org.dpppt.android.sdk.internal.backend.models.GaenSecondDay;
+import org.dpppt.android.sdk.internal.logger.LogLevel;
+import org.dpppt.android.sdk.internal.logger.Logger;
+import org.dpppt.android.sdk.internal.nearby.GaenStateHelper;
+import org.dpppt.android.sdk.internal.nearby.GoogleExposureClient;
+import org.dpppt.android.sdk.internal.nearby.TestGoogleExposureClient;
+import org.dpppt.android.sdk.internal.storage.PendingKeyUploadStorage;
+import org.dpppt.android.sdk.models.ApplicationInfo;
+import org.dpppt.android.sdk.models.ExposeeAuthMethodJson;
+import org.dpppt.android.sdk.util.DateUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class TEKReleaseTest {
+
+	Context context;
+	MockWebServer server;
+	TestGoogleExposureClient testGoogleExposureClient;
+	Instrumentation.ActivityMonitor monitor;
+	Instrumentation mInstrumentation;
+
+	@Before
+	public void setup() throws IOException {
+		mInstrumentation = InstrumentationRegistry.getInstrumentation();
+		context = mInstrumentation.getTargetContext();
+
+		Logger.init(context, LogLevel.DEBUG);
+
+		ProxyConfig.DISABLE_SYSTEM_PROXY = true;
+		GaenStateHelper.SET_GAEN_AVAILABILITY_AVAILABLE_FOR_TESTS = true;
+
+		server = new MockWebServer();
+		server.start();
+		AppConfigManager appConfigManager = AppConfigManager.getInstance(context);
+		DP3T.init(context, new ApplicationInfo("test", server.url("/bucket/").toString(), server.url("/report/").toString()),
+				null);
+		appConfigManager.setTracingEnabled(false);
+		DP3T.clearData(context);
+		DP3T.init(context, new ApplicationInfo("test", server.url("/bucket/").toString(), server.url("/report/").toString()),
+				null);
+		appConfigManager.setTracingEnabled(true);
+		PendingKeyUploadStorage.getInstance(context).clear();
+	}
+
+
+	@Test
+	public void testIAmInfectedKeyAlreadyReleased() throws Exception {
+
+		testGoogleExposureClient = new TestGoogleExposureClient(context, true);
+		GoogleExposureClient.wrapTestClient(testGoogleExposureClient);
+		testGoogleExposureClient.setTime(System.currentTimeMillis());
+
+		Activity activity = startEmptyActivity();
+
+		AtomicInteger exposedFakeRequestCounter = new AtomicInteger(0);
+		AtomicInteger exposedRequestCounter = new AtomicInteger(0);
+		AtomicInteger exposednextdayFakeRequestCounter = new AtomicInteger(0);
+		AtomicInteger exposednextdayRequestCounter = new AtomicInteger(0);
+		ArrayList<Integer> sentRollingStartNumbers = new ArrayList<>();
+
+		//Onset Date is 4 days ago
+		long onsetDate = System.currentTimeMillis() - 1000 * 60 * 60 * 96;
+		Gson gson = new Gson();
+
+		server.setDispatcher(new Dispatcher() {
+			@Override
+			public MockResponse dispatch(RecordedRequest request) {
+				String body = new String(request.getBody().readByteArray());
+				if (request.getPath().equals("/bucket/v1/gaen/exposed")) {
+					GaenRequest gaenRequest = gson.fromJson(body, new TypeToken<GaenRequest>() { }.getType());
+					int fake = gaenRequest.isFake();
+					if (fake == 1) exposedFakeRequestCounter.getAndIncrement();
+					else {
+						for (GaenKey k : gaenRequest.getGaenKeys()) {
+							if (!k.isFake()) {
+								sentRollingStartNumbers.add(k.getRollingStartNumber());
+							}
+						}
+						exposedRequestCounter.getAndIncrement();
+					}
+				}
+				if (request.getPath().equals("/bucket/v1/gaen/exposednextday")) {
+					GaenSecondDay gaenSecondDayRequest = gson.fromJson(body, new TypeToken<GaenSecondDay>() { }.getType());
+					int fake = gaenSecondDayRequest.isFake();
+					if (fake == 1) exposednextdayFakeRequestCounter.getAndIncrement();
+					else exposednextdayRequestCounter.getAndIncrement();
+				}
+				return new MockResponse().setResponseCode(200);
+			}
+		});
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		DP3T.sendIAmInfected(activity, new Date(onsetDate), new ExposeeAuthMethodJson(""), new ResponseCallback<Void>() {
+			@Override
+			public void onSuccess(Void response) {
+				countDownLatch.countDown();
+			}
+
+			@Override
+			public void onError(Throwable throwable) {
+				countDownLatch.countDown();
+			}
+		});
+		countDownLatch.await();
+
+		AtomicLong today = new AtomicLong(System.currentTimeMillis());
+		try {
+			new SyncWorker.SyncImpl(context, today.get()).doSync();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		assertEquals(1, exposedRequestCounter.get());
+		assertEquals(0, exposedFakeRequestCounter.get());
+		assertEquals(0, exposednextdayFakeRequestCounter.get());
+		assertEquals(0, exposednextdayRequestCounter.get());
+		assertFalse(DP3T.isTracingEnabled(context));
+		assertEquals(InfectionStatus.INFECTED, DP3T.getStatus(context).getInfectionStatus());
+		for (int k : sentRollingStartNumbers) {
+			assertTrue(k >= DateUtil.getRollingStartNumberForDate(onsetDate));
+			assertTrue(k <= DateUtil.getRollingStartNumberForDate(today.get()));
+		}
+
+		AtomicLong tomorrow = new AtomicLong(today.get() + 1000 * 60 * 60 * 24);
+		testGoogleExposureClient.setTime(tomorrow.get());
+
+		try {
+			new SyncWorker.SyncImpl(context, tomorrow.get()).doSync();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		mInstrumentation.removeMonitor(monitor);
+
+		assertEquals(1, exposedRequestCounter.get());
+		assertEquals(0, exposedFakeRequestCounter.get());
+		assertEquals(1, exposednextdayFakeRequestCounter.get());
+		assertEquals(0, exposednextdayRequestCounter.get());
+		assertFalse(DP3T.isTracingEnabled(context));
+		assertEquals(InfectionStatus.INFECTED, DP3T.getStatus(context).getInfectionStatus());
+	}
+
+	@Test
+	public void testIAmInfectedKeyNotReleased() throws Exception {
+
+		testGoogleExposureClient = new TestGoogleExposureClient(context, false);
+		GoogleExposureClient.wrapTestClient(testGoogleExposureClient);
+		testGoogleExposureClient.setTime(System.currentTimeMillis());
+
+		Activity activity = startEmptyActivity();
+
+		AtomicInteger exposedFakeRequestCounter = new AtomicInteger(0);
+		AtomicInteger exposedRequestCounter = new AtomicInteger(0);
+		AtomicInteger exposednextdayFakeRequestCounter = new AtomicInteger(0);
+		AtomicInteger exposednextdayRequestCounter = new AtomicInteger(0);
+		ArrayList<Integer> sentRollingStartNumbers = new ArrayList<>();
+		ArrayList<Integer> nextdaySentRollingStartNumbers = new ArrayList<>();
+
+		//Onset Date is 4 days ago
+		long onsetDate = System.currentTimeMillis() - 1000 * 60 * 60 * 96;
+		Gson gson = new Gson();
+
+		server.setDispatcher(new Dispatcher() {
+			@Override
+			public MockResponse dispatch(RecordedRequest request) {
+				String body = new String(request.getBody().readByteArray());
+				if (request.getPath().equals("/bucket/v1/gaen/exposed")) {
+					GaenRequest gaenRequest = gson.fromJson(body, new TypeToken<GaenRequest>() { }.getType());
+					int fake = gaenRequest.isFake();
+					if (fake == 1) exposedFakeRequestCounter.getAndIncrement();
+					else {
+						for (GaenKey k : gaenRequest.getGaenKeys()) {
+							if (!k.isFake()) {
+								sentRollingStartNumbers.add(k.getRollingStartNumber());
+							}
+						}
+						exposedRequestCounter.getAndIncrement();
+					}
+				}
+				if (request.getPath().equals("/bucket/v1/gaen/exposednextday")) {
+					GaenSecondDay gaenSecondDayRequest = gson.fromJson(body, new TypeToken<GaenSecondDay>() { }.getType());
+					int fake = gaenSecondDayRequest.isFake();
+					if (fake == 1) exposednextdayFakeRequestCounter.getAndIncrement();
+					else {
+						exposednextdayRequestCounter.getAndIncrement();
+						nextdaySentRollingStartNumbers.add(gaenSecondDayRequest.getDelayedKey().getRollingStartNumber());
+					}
+				}
+				return new MockResponse().setResponseCode(200);
+			}
+		});
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		DP3T.sendIAmInfected(activity, new Date(onsetDate), new ExposeeAuthMethodJson(""), new ResponseCallback<Void>() {
+			@Override
+			public void onSuccess(Void response) {
+				countDownLatch.countDown();
+			}
+
+			@Override
+			public void onError(Throwable throwable) {
+				countDownLatch.countDown();
+			}
+		});
+		countDownLatch.await();
+
+		AtomicLong today = new AtomicLong(System.currentTimeMillis());
+		try {
+			new SyncWorker.SyncImpl(context, today.get()).doSync();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		assertEquals(1, exposedRequestCounter.get());
+		assertEquals(0, exposedFakeRequestCounter.get());
+		assertEquals(0, exposednextdayFakeRequestCounter.get());
+		assertEquals(0, exposednextdayRequestCounter.get());
+		assertTrue(DP3T.isTracingEnabled(context));
+		assertEquals(InfectionStatus.INFECTED, DP3T.getStatus(context).getInfectionStatus());
+		for (int k : sentRollingStartNumbers) {
+			assertTrue(k >= DateUtil.getRollingStartNumberForDate(onsetDate));
+			assertTrue(k < DateUtil.getRollingStartNumberForDate(today.get()));
+		}
+
+		AtomicLong tomorrow = new AtomicLong(today.get() + 1000 * 60 * 60 * 24);
+		testGoogleExposureClient.setTime(tomorrow.get());
+
+		try {
+			new SyncWorker.SyncImpl(context, tomorrow.get()).doSync();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		mInstrumentation.removeMonitor(monitor);
+
+		assertEquals(1, exposedRequestCounter.get());
+		assertEquals(0, exposedFakeRequestCounter.get());
+		assertEquals(0, exposednextdayFakeRequestCounter.get());
+		assertEquals(1, exposednextdayRequestCounter.get());
+		assertFalse(DP3T.isTracingEnabled(context));
+		assertEquals(InfectionStatus.INFECTED, DP3T.getStatus(context).getInfectionStatus());
+		for (int k : nextdaySentRollingStartNumbers) {
+			//the rolling start number that is sent tomorrow must be equals to today's rolling start number
+			assertEquals(k, DateUtil.getRollingStartNumberForDate(today.get()));
+		}
+	}
+
+
+	private Activity startEmptyActivity() {
+		Instrumentation.ActivityMonitor monitor = mInstrumentation.addMonitor(TestActivity.class.getName(), null, false);
+		Intent intent = new Intent(Intent.ACTION_MAIN);
+		intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+		intent.setClassName(mInstrumentation.getTargetContext(), TestActivity.class.getName());
+		mInstrumentation.startActivitySync(intent);
+
+		Activity activity = mInstrumentation.waitForMonitor(monitor);
+		assertNotNull(activity);
+		return activity;
+	}
+
+}

--- a/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/TestActivity.java
+++ b/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/TestActivity.java
@@ -1,0 +1,8 @@
+package org.dpppt.android.sdk.internal;
+
+import android.app.Activity;
+
+public class TestActivity extends Activity {
+
+
+}

--- a/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/nearby/TestGoogleExposureClient.java
+++ b/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/nearby/TestGoogleExposureClient.java
@@ -26,14 +26,23 @@ import com.google.android.gms.nearby.exposurenotification.*;
 import com.google.android.gms.tasks.Task;
 
 import org.dpppt.android.sdk.internal.util.Json;
+import org.dpppt.android.sdk.models.DayDate;
+import org.dpppt.android.sdk.util.DateUtil;
 
 public class TestGoogleExposureClient implements ExposureNotificationClient {
 
 	private Context context;
 	private int provideDiagnosisKeysCounter = 0;
+	private boolean currentDayKeyReleased = false;
+	private long time = System.currentTimeMillis();
 
 	public TestGoogleExposureClient(Context context) {
 		this.context = context;
+	}
+
+	public TestGoogleExposureClient(Context context, boolean currentDayKeyReleased) {
+		this.context = context;
+		this.currentDayKeyReleased = currentDayKeyReleased;
 	}
 
 	@Override
@@ -53,7 +62,18 @@ public class TestGoogleExposureClient implements ExposureNotificationClient {
 
 	@Override
 	public Task<List<TemporaryExposureKey>> getTemporaryExposureKeyHistory() {
-		return new DummyTask<>(new ArrayList<>());
+		ArrayList<TemporaryExposureKey> temporaryExposureKeys = new ArrayList<>();
+		for (int i = 1; i<20; i++){
+			temporaryExposureKeys.add(new TemporaryExposureKey.TemporaryExposureKeyBuilder()
+					.setRollingStartIntervalNumber(DateUtil.getRollingStartNumberForDate(new DayDate(time).subtractDays(i)))
+					.build());
+		}
+		if (currentDayKeyReleased) {
+			temporaryExposureKeys.add(new TemporaryExposureKey.TemporaryExposureKeyBuilder()
+					.setRollingStartIntervalNumber(DateUtil.getRollingStartNumberForDate(new DayDate(time)))
+					.build());
+		}
+		return new DummyTask<>(temporaryExposureKeys);
 	}
 
 	@Override
@@ -103,6 +123,10 @@ public class TestGoogleExposureClient implements ExposureNotificationClient {
 
 	public int getProvideDiagnosisKeysCounter() {
 		return provideDiagnosisKeysCounter;
+	}
+
+	public void setTime(long time){
+		this.time = time;
 	}
 
 	public static class ExposureTestParameters {

--- a/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/nearby/TestGoogleExposureClient.java
+++ b/dp3t-sdk/sdk/src/androidTest/java/org/dpppt/android/sdk/internal/nearby/TestGoogleExposureClient.java
@@ -63,7 +63,7 @@ public class TestGoogleExposureClient implements ExposureNotificationClient {
 	@Override
 	public Task<List<TemporaryExposureKey>> getTemporaryExposureKeyHistory() {
 		ArrayList<TemporaryExposureKey> temporaryExposureKeys = new ArrayList<>();
-		for (int i = 1; i<20; i++){
+		for (int i = 1; i<14; i++){
 			temporaryExposureKeys.add(new TemporaryExposureKey.TemporaryExposureKeyBuilder()
 					.setRollingStartIntervalNumber(DateUtil.getRollingStartNumberForDate(new DayDate(time).subtractDays(i)))
 					.build());

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/models/GaenRequest.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/models/GaenRequest.java
@@ -37,7 +37,7 @@ public class GaenRequest {
 			rollingStartNumber = Math.min(rollingStartNumber, temporaryExposureKey.getRollingStartIntervalNumber());
 		}
 		SecureRandom random = new SecureRandom();
-		while (keys.size() < 14) {
+		while (keys.size() < 30) {
 			byte[] bytes = new byte[16];
 			random.nextBytes(bytes);
 			rollingStartNumber = rollingStartNumber - 144;

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/models/GaenSecondDay.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/models/GaenSecondDay.java
@@ -19,4 +19,12 @@ public class GaenSecondDay {
 		this.fake = gaenKey.fake;
 	}
 
+	public Integer isFake() {
+		return this.fake;
+	}
+
+	public GaenKey getDelayedKey() {
+		return delayedKey;
+	}
+
 }


### PR DESCRIPTION
This PR prepares the SDK for same day TEK release. There are two changes:
1) we always upload 30 keys, to be sure that all available keys fit into the upload. With same day TEK release multiple TEKs are generated for the same day which theoretically can lead to more than 14 keys during the last 14 days.
2) the next day TEK upload that was used to upload the current days TEK is only done if the current day TEK is not already released when asking for the TEKs. If we do not need to do a next day TEK upload, we schedule a fake next day upload to make sure we always have the same network pattern. Once most devices will have same day TEK release enabled, we will be able to completely remove the next day upload for real and fake uploads.

Closes #194 