### PR TITLE
Feature/make sure to always stop tracing after reporting sick

### DIFF
--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.java
@@ -344,6 +344,8 @@ public class SyncWorker extends Worker {
 						}
 						if (gaenKey == null) {
 							//key for specified rollingStartNumber was not found, user must have cleared data
+							DP3T.stop(context);
+							appConfigManager.setIAmInfectedIsResettable(true);
 							continue;
 						}
 					} else {


### PR DESCRIPTION
Make sure that we also stop tracing (and allow to reset the I am infected state) at some point, also if we for some reason are not able to retrieve the key of the reporting date the next day. otherwise we would land in a state were the tracing keeps running and the user is not able to remove the infected state. This is only relevant for the case when the current day TEK is not released immediately.