### PR TITLE
do not reset sync-errors if sync is skipped due to rate limit limitations

### DIFF
--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.java
@@ -134,7 +134,11 @@ public class SyncWorker extends Worker {
 					uploadPendingKeys(context);
 
 					if (DP3T.isTracingEnabled(context) && !Boolean.FALSE.equals(GaenStateCache.isGaenEnabled())) {
-						doSyncInternal(context);
+						boolean syncWasExecuted = doSyncInternal(context);
+						if (!syncWasExecuted) {
+							Logger.i(TAG, "sync skipped due to rate limit");
+							return;
+						}
 						Logger.i(TAG, "synced");
 						AppConfigManager.getInstance(context).setLastSyncNetworkSuccess(true);
 					}
@@ -151,7 +155,7 @@ public class SyncWorker extends Worker {
 			}
 		}
 
-		private void doSyncInternal(Context context) throws Exception {
+		private boolean doSyncInternal(Context context) throws Exception {
 			AppConfigManager appConfigManager = AppConfigManager.getInstance(context);
 			ApplicationInfo appConfig = appConfigManager.getAppConfig();
 
@@ -203,6 +207,10 @@ public class SyncWorker extends Worker {
 				}
 
 				cleanupOldKeyFiles(context);
+
+				return true;
+			} else {
+				return false;
 			}
 		}
 


### PR DESCRIPTION
keep error until next proper successful sync. Otherwise the error would disappear for the user, although the problem still exists.