### PR TITLE
persist sync error state

### DIFF
--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/TracingStatus.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/TracingStatus.java
@@ -71,7 +71,7 @@ public class TracingStatus {
 		SYNC_ERROR_SIGNATURE(R.string.dp3t_sdk_service_notification_error_sync_signature),
 		SYNC_ERROR_API_EXCEPTION(R.string.dp3t_sdk_service_notification_error_sync_api);
 
-		@StringRes private int errorString;
+		@StringRes private final int errorString;
 		private String errorCode;
 
 		ErrorState(@StringRes int errorString) {

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/ErrorHelper.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/ErrorHelper.java
@@ -33,7 +33,6 @@ import org.dpppt.android.sdk.backend.SignatureException;
 import org.dpppt.android.sdk.internal.backend.ServerTimeOffsetException;
 import org.dpppt.android.sdk.internal.backend.StatusCodeException;
 import org.dpppt.android.sdk.internal.backend.SyncErrorState;
-import org.dpppt.android.sdk.internal.logger.Logger;
 import org.dpppt.android.sdk.internal.nearby.ApiExceptionUtil;
 import org.dpppt.android.sdk.internal.nearby.GaenStateCache;
 import org.dpppt.android.sdk.internal.util.LocationServiceUtil;
@@ -73,14 +72,8 @@ public class ErrorHelper {
 			errors.add(ErrorState.BATTERY_OPTIMIZER_ENABLED);
 		}
 
-		if (!AppConfigManager.getInstance(context).getLastSyncNetworkSuccess()) {
-			SyncErrorState syncErrorState = SyncErrorState.getInstance();
-			ErrorState syncError = syncErrorState.getSyncError();
-			if (syncError == null) {
-				Logger.w(TAG, "lost sync error state");
-				syncError = ErrorState.SYNC_ERROR_NETWORK;
-				syncError.setErrorCode("LOST");
-			}
+		ErrorState syncError = SyncErrorState.getInstance().getSyncError(context);
+		if (syncError != null) {
 			errors.add(syncError);
 		}
 

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.kt
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/SyncWorker.kt
@@ -117,15 +117,13 @@ class SyncWorker(context: Context, workerParams: WorkerParameters) : CoroutineWo
 							return
 						}
 						Logger.i(TAG, "synced")
-						AppConfigManager.getInstance(context).lastSyncNetworkSuccess = true
 					}
-					SyncErrorState.getInstance().syncError = null
+					SyncErrorState.getInstance().setSyncError(context, null)
 					BroadcastHelper.sendUpdateAndErrorBroadcast(context)
 				} catch (e: Exception) {
 					Logger.e(TAG, "sync", e)
-					AppConfigManager.getInstance(context).lastSyncNetworkSuccess = false
 					val syncError = ErrorHelper.getSyncErrorFromException(e, true)
-					SyncErrorState.getInstance().syncError = syncError
+					SyncErrorState.getInstance().setSyncError(context, syncError)
 					BroadcastHelper.sendUpdateAndErrorBroadcast(context)
 					throw e
 				}

--- a/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/SyncErrorState.java
+++ b/dp3t-sdk/sdk/src/main/java/org/dpppt/android/sdk/internal/backend/SyncErrorState.java
@@ -9,7 +9,12 @@
  */
 package org.dpppt.android.sdk.internal.backend;
 
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
 import org.dpppt.android.sdk.TracingStatus.ErrorState;
+import org.dpppt.android.sdk.internal.AppConfigManager;
 
 public class SyncErrorState {
 
@@ -28,11 +33,16 @@ public class SyncErrorState {
 		return instance;
 	}
 
-	public void setSyncError(ErrorState syncError) {
+	public void setSyncError(Context context, @Nullable ErrorState syncError) {
 		this.syncError = syncError;
+		AppConfigManager.getInstance(context).setLastSyncNetworkError(syncError);
 	}
 
-	public ErrorState getSyncError() {
+	@Nullable
+	public ErrorState getSyncError(Context context) {
+		if (syncError == null) {
+			syncError = AppConfigManager.getInstance(context).getLastSyncNetworkError();
+		}
 		return syncError;
 	}
 


### PR DESCRIPTION
Prevents losing any sync error state after process restart, causing a sync error "LOST".